### PR TITLE
fix(PLL3): use base rate to prevent panic

### DIFF
--- a/src/system.rs
+++ b/src/system.rs
@@ -35,8 +35,8 @@ const PLL2_Q_HZ: Hertz = Hertz::from_raw(PLL2_P_HZ.raw() / 2); // No divder give
 const PLL2_R_HZ: Hertz = Hertz::from_raw(PLL2_P_HZ.raw() / 4); // No divder given, what's the default?
 
 const PLL3_P_HZ: Hertz = Hertz::from_raw(AUDIO_SAMPLE_HZ.raw() * 257);
-const PLL3_Q_HZ: Hertz = Hertz::from_raw(PLL3_P_HZ.raw() / 4);
-const PLL3_R_HZ: Hertz = Hertz::from_raw(PLL3_P_HZ.raw() / 16);
+const PLL3_Q_HZ: Hertz = Hertz::from_raw(PLL3_P_HZ.raw());
+const PLL3_R_HZ: Hertz = Hertz::from_raw(PLL3_P_HZ.raw());
 
 pub struct System {
     pub gpio: crate::gpio::GPIO,


### PR DESCRIPTION
PLL3 Q and R were panic-ing because their dividers were too high on account of their rate being too low. See [here][1].

PLL3 P was set to 257 * audio rate to follow the audio example in the hal crate. Because of that, when divided, Q and R ended up too low, causing the referenced panic.

For now, set them to the base rate as I cannot see where they are being used. If/when we need to change them then we can deal with it then. libDaisy does not follow the PLL setup in this crate, and I am unsure at this point why this crate deviates.

[1]: https://github.com/stm32-rs/stm32h7xx-hal/blob/b4fb6de6fb34ea77269a951ce366601e4bab3915/src/rcc/pll.rs#L300-L301